### PR TITLE
Add JSON dependency to Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20220320</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Given that inside the `Stmt` class JSON classes are used, I added the JSON as a dependency to the Maven POM file.